### PR TITLE
test: add CUDA support to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,16 +26,18 @@ commands:
             echo 'export PATH="$HOME:~/.cargo/bin:/usr/local/cuda-11.2/bin:$PATH"' | tee --append $BASH_ENV
             source $BASH_ENV
 
-  test_target:
+  test-with-args:
     parameters:
-      target:
+      cargo-args:
+        description: Addtional arguments for the cargo command
         type: string
+        default: ""
     steps:
-      - *restore-workspace
-      - *restore-cache
+      - run: sudo apt update
+      - run: sudo apt install -y ocl-icd-opencl-dev
       - run:
-          name: Test (<< parameters.target >>)
-          command: TARGET=<< parameters.target >> cargo test --all
+          name: Test (<< parameters.cargo-args >>)
+          command: cargo test --workspace --no-default-features  << parameters.cargo-args >>
           no_output_timeout: 15m
 
 jobs:
@@ -77,14 +79,23 @@ jobs:
             - "~/.cargo"
             - "~/.rustup"
 
-  test_x86_64-unknown-linux-gnu:
+  test_cuda:
     executor: default
     steps:
+      - *restore-workspace
+      - *restore-cache
       - set-env-path
-      - run: sudo apt update
-      - run: sudo apt install -y ocl-icd-opencl-dev
-      - test_target:
-          target: "x86_64-unknown-linux-gnu"
+      - test-with-args:
+          cargo-args: "--features cuda"
+
+  test_opencl:
+    executor: default
+    steps:
+      - *restore-workspace
+      - *restore-cache
+      - set-env-path
+      - test-with-args:
+          cargo-args: "--features opencl"
 
   rustfmt:
     executor: default
@@ -129,7 +140,10 @@ workflows:
       - clippy:
           requires:
             - cargo_fetch
-      - test_x86_64-unknown-linux-gnu:
+      - test_cuda:
+          requires:
+            - cargo_fetch
+      - test_opencl:
           requires:
             - cargo_fetch
       - build:

--- a/ec-gpu-gen/Cargo.toml
+++ b/ec-gpu-gen/Cargo.toml
@@ -14,7 +14,12 @@ ec-gpu = { path = "../ec-gpu", git = "https://github.com/filecoin-project/ec-gpu
 [dev-dependencies]
 ff = "0.11.0"
 blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master", features = ["gpu"] }
-ocl = { version = "0.19.4", package = "fil-ocl"}
+rust-gpu-tools = { git = "https://github.com/filecoin-project/rust-gpu-tools", branch = "master", default-features = false }
 rand = "0.8"
 lazy_static = "1.2"
+tempfile = "3.2.0"
 
+[features]
+default = ["opencl", "cuda"]
+cuda = ["rust-gpu-tools/cuda"]
+opencl = ["rust-gpu-tools/opencl"]

--- a/ec-gpu-gen/src/cl/test.cl
+++ b/ec-gpu-gen/src/cl/test.cl
@@ -31,6 +31,8 @@ KERNEL void test_double_32(Scalar32 a, GLOBAL Scalar32 *result) {
 }
 
 ////////////
+// CUDA doesn't support 64-bit limbs
+#ifndef CUDA
 
 KERNEL void test_add_64(Scalar64 a, Scalar64 b, GLOBAL Scalar64 *result) {
   *result = Scalar64_add(a, b);
@@ -63,3 +65,4 @@ KERNEL void test_sqr_64(Scalar64 a, GLOBAL Scalar64 *result) {
 KERNEL void test_double_64(Scalar64 a, GLOBAL Scalar64 *result) {
   *result = Scalar64_double(a);
 }
+#endif


### PR DESCRIPTION
It's now possible to run the tests also on CUDA.

All this sadly needs a lot of boilerplate code. It seems like rust-gpu-tools could need some improvements on that front.