### PR TITLE
fix: no default features

### DIFF
--- a/ec-gpu-gen/Cargo.toml
+++ b/ec-gpu-gen/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = "1.2"
 tempfile = "3.2.0"
 
 [features]
-default = ["opencl", "cuda"]
+default = []
+# Those features are needed for running the tests only
 cuda = ["rust-gpu-tools/cuda"]
 opencl = ["rust-gpu-tools/opencl"]


### PR DESCRIPTION
The `cuda` and `opencl` features are only needed for testing.