### PR TITLE
fix: rename features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
       - *restore-cache
       - set-env-path
       - test-with-args:
-          cargo-args: "--features cuda"
+          cargo-args: "--features tests-cuda"
 
   test_opencl:
     executor: default
@@ -95,7 +95,7 @@ jobs:
       - *restore-cache
       - set-env-path
       - test-with-args:
-          cargo-args: "--features opencl"
+          cargo-args: "--features tests-opencl"
 
   rustfmt:
     executor: default

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ bool FIELD_get_bit(FIELD l, uint i); // Get `i`th bit (From most significant dig
 uint FIELD_get_bits(FIELD l, uint skip, uint window); // Get `window` consecutive bits, (Starting from `skip`th bit from most significant digit)
 ```
 
+## Tests
+
+In order to run the tests, you need to enable one (or both) of `tests-cuda` and `tests-opencl`.
+
 ## License
 
 Licensed under either of

--- a/ec-gpu-gen/Cargo.toml
+++ b/ec-gpu-gen/Cargo.toml
@@ -22,5 +22,5 @@ tempfile = "3.2.0"
 [features]
 default = []
 # Those features are needed for running the tests only
-cuda = ["rust-gpu-tools/cuda"]
-opencl = ["rust-gpu-tools/opencl"]
+tests-cuda = ["rust-gpu-tools/cuda"]
+tests-opencl = ["rust-gpu-tools/opencl"]


### PR DESCRIPTION
The current features are only used for the tests, make this clearer
by prefixing them with `tests-`.