### PR TITLE
chore: list GPUs on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ jobs:
       - *restore-cache
       - set-env-path
       - install-gpu-deps
+      - run: nvidia-smi --list-gpus
       - run:
           name: Test (<< parameters.cargo-args >>)
           command: cargo test --workspace << parameters.cargo-args >>


### PR DESCRIPTION
Sometimes CI is failing, I suspect an environment issue. Print the
GPU's UUID to see if it always happens on the same GPU.