### PR TITLE
fix: make OpenCL use 64-bit limbs

### DIFF
--- a/ec-gpu-gen/src/fft.rs
+++ b/ec-gpu-gen/src/fft.rs
@@ -41,8 +41,8 @@ impl<'a, E: Engine + GpuEngine> SingleFftKernel<'a, E> {
         maybe_abort: Option<&'a (dyn Fn() -> bool + Send + Sync)>,
     ) -> EcResult<Self> {
         let source = match device.vendor() {
-            Vendor::Nvidia => crate::gen_source::<E, Limb64>(),
-            _ => crate::gen_source::<E, Limb32>(),
+            Vendor::Nvidia => crate::gen_source::<E, Limb32>(),
+            _ => crate::gen_source::<E, Limb64>(),
         };
         let program = program::program::<E>(device, &source)?;
 

--- a/ec-gpu-gen/src/multiexp.rs
+++ b/ec-gpu-gen/src/multiexp.rs
@@ -121,8 +121,8 @@ where
         let n = std::cmp::min(max_n, best_n);
 
         let source = match device.vendor() {
-            Vendor::Nvidia => crate::gen_source::<E, Limb64>(),
-            _ => crate::gen_source::<E, Limb32>(),
+            Vendor::Nvidia => crate::gen_source::<E, Limb32>(),
+            _ => crate::gen_source::<E, Limb64>(),
         };
         let program = program::program::<E>(device, &source)?;
 


### PR DESCRIPTION
The refactoring that moved code from bellperson into this library lead
to a regression. Accidentally OpenCL was using 32-bit limbs, which
should lead to less performance than using 64-bit limbs.

The CUDA code path was always using the expected 32-bit limbs. Even
if it doesn't look like it from this change, it was the case as the
CUDA kernels are compiled at compile-time, the limb size is correctly
specified in build.rs.