### PR TITLE
chore: make sure that the documention is available on doc.rs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,21 @@ jobs:
       - run:
           name: Run cargo release build
           command: cargo build --workspace --release
+  rustdoc:
+    executor: default
+    environment:
+      # Making sure that the documentation can be built without having the NVIDIA toolkit
+      # installed.
+      DOCS_RS: true
+    steps:
+      - *restore-workspace
+      - *restore-cache
+      - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV && source $BASH_ENV
+      - run:
+          name: Run rustdoc
+          command: |
+            cargo rustdoc --package ec-gpu --all-features -- -D warnings
+            cargo rustdoc --package ec-gpu-gen --all-features -- -D warnings
 
 workflows:
   version: 2.1
@@ -204,5 +219,8 @@ workflows:
           requires:
             - cargo_fetch
       - build:
+          requires:
+            - cargo_fetch
+      - rustdoc:
           requires:
             - cargo_fetch

--- a/ec-gpu-gen/build.rs
+++ b/ec-gpu-gen/build.rs
@@ -18,6 +18,13 @@ fn main() {
     #[path = "src/source.rs"]
     mod source;
 
+    // This is a hack for the case when the documentation is built on docs.rs. For the
+    // documentation  we don't need a properly compiled kernel, but just some arbitrary bytes.
+    if env::var("DOCS_RS").is_ok() {
+        println!("cargo:rustc-env=CUDA_KERNEL_FATBIN=../build.rs");
+        return;
+    }
+
     let kernel_source = source::gen_source::<Bls12, source::Limb32>();
 
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR was not set.");
@@ -69,7 +76,7 @@ fn main() {
             .arg(&fatbin_path)
             .arg(&source_path)
             .status()
-            .expect("Cannot run nvcc.");
+            .expect("Cannot run nvcc. Install the NVIDIA toolkit or disable the `cuda` feature.");
 
         if !status.success() {
             panic!(


### PR DESCRIPTION
Due to the CUDA kernel compilation the documentation creation on
docs.rs fails. With this commit we skip that step for the docs.rs
platform, so that the documentation is successfully built there.

Fixes #19.