### PR TITLE
chore: update dependencies

### DIFF
--- a/ec-gpu-gen/Cargo.toml
+++ b/ec-gpu-gen/Cargo.toml
@@ -12,12 +12,12 @@ license = "MIT/Apache-2.0"
 bitvec = "0.22.3"
 crossbeam-channel = "0.5.1"
 ec-gpu = "0.1.0"
-ff = "0.11.0"
-group = "0.11.0"
+ff = { version = "0.12.0", default-features = false }
+group = "0.12.0"
 log = "0.4.14"
 num_cpus = "1.13.0"
 once_cell = "1.8.0"
-pairing = "0.21.0"
+pairing = "0.22.0"
 rayon = "1.5.1"
 rust-gpu-tools = { version = "0.6.0", default-features = false, optional = true }
 temp-env = "0.2.0"
@@ -25,7 +25,7 @@ thiserror = "1.0.30"
 yastl = "0.1.2"
 
 [dev-dependencies]
-blstrs = { version = "0.4.0", features = ["gpu"] }
+blstrs = { version = "0.5.0", features = ["gpu"] }
 rand = "0.8"
 lazy_static = "1.2"
 tempfile = "3.2.0"
@@ -33,7 +33,7 @@ rand_core = "0.6.3"
 rand_xorshift = "0.3.0"
 
 [build-dependencies]
-blstrs = "0.4.0"
+blstrs = "0.5.0"
 ec-gpu = "0.1.0"
 execute = "0.2.9"
 hex = "0.4"


### PR DESCRIPTION
BREAKING CHANGE: the upgraded dependencies define traits

If you have traits from different versions of dependencies, then things
will break. Hence those updates will be in a breaking change release.