### PR TITLE
feat: add a benchmark for multiexp

### DIFF
--- a/ec-gpu-gen/Cargo.toml
+++ b/ec-gpu-gen/Cargo.toml
@@ -31,6 +31,7 @@ lazy_static = "1.2"
 tempfile = "3.2.0"
 rand_core = "0.6.3"
 rand_xorshift = "0.3.0"
+criterion = "0.3.5"
 
 [build-dependencies]
 blstrs = "0.5.0"
@@ -45,3 +46,8 @@ cuda = ["rust-gpu-tools/cuda"]
 opencl = ["rust-gpu-tools/opencl"]
 fft = []
 multiexp = []
+
+[[bench]]
+name = "multiexp"
+harness = false
+required-features = ["multiexp"]

--- a/ec-gpu-gen/benches/multiexp.rs
+++ b/ec-gpu-gen/benches/multiexp.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use blstrs::Bls12;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use ec_gpu_gen::multiexp::MultiexpKernel;
+use ec_gpu_gen::multiexp_cpu::SourceBuilder;
+use ec_gpu_gen::threadpool::Worker;
+use ff::{Field, PrimeField};
+use group::{Curve, Group};
+use pairing::Engine;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rust_gpu_tools::Device;
+
+/// The power that will be used to define the maximum number of elements. The number of elements
+/// is `2^MAX_ELEMENTS_POWER`.
+const MAX_ELEMENTS_POWER: usize = 29;
+/// The maximum number of elements for this benchmark.
+const MAX_ELEMENTS: usize = 1 << MAX_ELEMENTS_POWER;
+
+fn bench_multiexp(crit: &mut Criterion) {
+    let mut group = crit.benchmark_group("multiexp");
+    // The difference between runs is so little, hence a low sample size is OK.
+    group.sample_size(10);
+
+    let devices = Device::all();
+    let mut kern = MultiexpKernel::<Bls12>::create(&devices).expect("Cannot initialize kernel!");
+    let pool = Worker::new();
+    let max_bases: Vec<_> = (0..MAX_ELEMENTS)
+        .into_par_iter()
+        .map(|_| <Bls12 as Engine>::G1::random(rand::thread_rng()).to_affine())
+        .collect();
+    let max_exponents: Vec<_> = (0..MAX_ELEMENTS)
+        .into_par_iter()
+        .map(|_| <Bls12 as Engine>::Fr::random(rand::thread_rng()).to_repr())
+        .collect();
+
+    let num_elements: Vec<_> = (10..MAX_ELEMENTS_POWER).map(|shift| 1 << shift).collect();
+    for num in num_elements {
+        group.bench_with_input(BenchmarkId::from_parameter(num), &num, |bencher, &num| {
+            let (bases, skip) = SourceBuilder::get((Arc::new(max_bases[0..num].to_vec()), 0));
+            let exponents = Arc::new(max_exponents[0..num].to_vec());
+
+            bencher.iter(|| {
+                black_box(
+                    kern.multiexp(&pool, bases.clone(), exponents.clone(), skip)
+                        .unwrap(),
+                );
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_multiexp);
+criterion_main!(benches);


### PR DESCRIPTION
It is now possible to benchmark multiexp. The largest benchmark likely
needs more memory than the GPU has. This is done in order to make sure
that splitting the data into two runs also performs well.

With the default features, the benchmark is run on CUDA. To make sure
it is run with OpenCL only you can either set `EC_GPU_FRAMEWORK=opencl`
or disable the `cuda` feature via.

    cargo bench --no-default-features --features multiexp,opencl multiexp