### PR TITLE
chore: run tests on CI sequentially

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,8 @@ jobs:
       - run: nvidia-smi --list-gpus
       - run:
           name: Test (<< parameters.cargo-args >>)
-          command: cargo test --workspace << parameters.cargo-args >>
+          # GPU tests are best run sequentially so that they don't interfere with each other.
+          command: cargo test --workspace << parameters.cargo-args >> -- --test-threads=1
 
   rustfmt:
     executor: default


### PR DESCRIPTION
When run in parallel, tests sometime fail with "No GPU found".