### PR TITLE
feat: re-organize ec-gpu traits

### DIFF
--- a/ec-gpu/src/lib.rs
+++ b/ec-gpu/src/lib.rs
@@ -1,22 +1,61 @@
-/// Describes how to generate the elliptic curve operations for
-/// - `Scalar`
-/// - `Fp`
-/// - `Fp2`
-/// - `G1`
-/// - `G2`
-pub trait GpuEngine {
-    type Scalar: GpuField;
-    type Fp: GpuField;
+/// The name that is used in the GPU source code to identify the item that is used.
+pub trait GpuName {
+    /// A unique name for the item.
+    ///
+    /// To make the uniqueness easier to implement, use the [`name`] macro. It produces a unique
+    /// name, based on the module path and the type of the item itself. That identifier might not
+    /// be stable across different versions of a crate, but this is OK as kernel sources/binaries
+    /// are always bundled with a library and not re-used between versions.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// struct Fp;
+    ///
+    /// impl ec_gpu::GpuName for Fp {
+    ///     fn name() -> String {
+    ///         ec_gpu::name!()
+    ///     }
+    /// }
+    /// ```
+    fn name() -> String;
 }
 
-/// Describes how to generate the gpu sources for a Field.
-pub trait GpuField {
-    /// Returns `1` as a vector of 32bit limbs.
+/// A prime field that returns the values in a representation that is suited for the use on a GPU.
+pub trait GpuField: GpuName {
+    /// Returns `1` as a vector of 32-bit limbs in little-endian non-Montgomery form (least
+    /// significant limb first).
     fn one() -> Vec<u32>;
 
-    /// Returns `R ^ 2 mod P` as a vector of 32bit limbs.
+    /// Returns `R ^ 2 mod P` as a vector of 32-bit limbs in little-endian non-Montgomery form
+    /// (least significant limb first).
     fn r2() -> Vec<u32>;
 
-    /// Returns the field modulus in non-Montgomery form (least significant limb first).
+    /// Returns the field modulus as a vector of 32-bit limbs in non-Montgomery form (least
+    /// significant limb first).
     fn modulus() -> Vec<u32>;
+
+    /// If the field is an extension field, then the name of the sub-field is returned.
+    fn sub_field_name() -> Option<String> {
+        None
+    }
+}
+
+/// Macro to get a unique name of an item.
+///
+/// The name is a string that consists of the module path and the type name. All non-alphanumeric
+/// characters are replaced with underscores, so that it's an identifier that doesn't cause any
+/// issues with C compilers.
+#[macro_export]
+macro_rules! name {
+    () => {{
+        let mod_path = module_path!();
+        let type_name = core::any::type_name::<Self>();
+        let name = if type_name.starts_with(mod_path) {
+            type_name.into()
+        } else {
+            [mod_path, "__", type_name].concat()
+        };
+        name.replace(|c: char| !c.is_ascii_alphanumeric(), "_")
+    }};
 }


### PR DESCRIPTION
The ec-gpu traits are re-organized.

BREAKING CHANGE: The `GpuEngine` trait is removed, as it was specific
to pairing friendlt elliptic curves.

The `GpuField` trait gains a new method called `sub_field_name`, which
only matters for extension fields. It has a default implementation, so
existing implementations don't need to change.

A new trait called `GpuName` is introduced, which every `GpuField` needs
to implement. It contains the name of the object it's implemented for,
which is then used in the generated source code as identifier.