### PR TITLE
fix: name jacobian representation more explicitly

### DIFF
--- a/ec-gpu-gen/src/cl/ec.cl
+++ b/ec-gpu-gen/src/cl/ec.cl
@@ -1,6 +1,6 @@
 // Elliptic curve operations (Short Weierstrass Jacobian form)
 
-#define POINT_ZERO ((POINT_projective){FIELD_ZERO, FIELD_ONE, FIELD_ZERO})
+#define POINT_ZERO ((POINT_jacobian){FIELD_ZERO, FIELD_ONE, FIELD_ZERO})
 
 typedef struct {
   FIELD x;
@@ -11,10 +11,10 @@ typedef struct {
   FIELD x;
   FIELD y;
   FIELD z;
-} POINT_projective;
+} POINT_jacobian;
 
 // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#doubling-dbl-2009-l
-DEVICE POINT_projective POINT_double(POINT_projective inp) {
+DEVICE POINT_jacobian POINT_double(POINT_jacobian inp) {
   const FIELD local_zero = FIELD_ZERO;
   if(FIELD_eq(inp.z, local_zero)) {
       return inp;
@@ -42,7 +42,7 @@ DEVICE POINT_projective POINT_double(POINT_projective inp) {
 }
 
 // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-madd-2007-bl
-DEVICE POINT_projective POINT_add_mixed(POINT_projective a, POINT_affine b) {
+DEVICE POINT_jacobian POINT_add_mixed(POINT_jacobian a, POINT_affine b) {
   const FIELD local_zero = FIELD_ZERO;
   if(FIELD_eq(a.z, local_zero)) {
     const FIELD local_one = FIELD_ONE;
@@ -67,7 +67,7 @@ DEVICE POINT_projective POINT_add_mixed(POINT_projective a, POINT_affine b) {
   FIELD r = FIELD_sub(s2, a.y); r = FIELD_double(r); // r = 2*(S2-Y1)
   const FIELD v = FIELD_mul(a.x, i);
 
-  POINT_projective ret;
+  POINT_jacobian ret;
 
   // X3 = r^2 - J - 2*V
   ret.x = FIELD_sub(FIELD_sub(FIELD_sqr(r), j), FIELD_double(v));
@@ -82,7 +82,7 @@ DEVICE POINT_projective POINT_add_mixed(POINT_projective a, POINT_affine b) {
 }
 
 // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-add-2007-bl
-DEVICE POINT_projective POINT_add(POINT_projective a, POINT_projective b) {
+DEVICE POINT_jacobian POINT_add(POINT_jacobian a, POINT_jacobian b) {
 
   const FIELD local_zero = FIELD_ZERO;
   if(FIELD_eq(a.z, local_zero)) return b;

--- a/ec-gpu-gen/src/cl/multiexp.cl
+++ b/ec-gpu-gen/src/cl/multiexp.cl
@@ -10,8 +10,8 @@
 
 KERNEL void POINT_multiexp(
     GLOBAL POINT_affine *bases,
-    GLOBAL POINT_projective *buckets,
-    GLOBAL POINT_projective *results,
+    GLOBAL POINT_jacobian *buckets,
+    GLOBAL POINT_jacobian *results,
     GLOBAL EXPONENT *exps,
     uint n,
     uint num_groups,
@@ -28,7 +28,7 @@ KERNEL void POINT_multiexp(
   // Each thread has its own set of buckets in global memory.
   buckets += bucket_len * gid;
 
-  const POINT_projective local_zero = POINT_ZERO;
+  const POINT_jacobian local_zero = POINT_ZERO;
   for(uint i = 0; i < bucket_len; i++) buckets[i] = local_zero;
 
   const uint len = (uint)ceil(n / (float)num_groups); // Num of elements in each group
@@ -40,7 +40,7 @@ KERNEL void POINT_multiexp(
   const uint bits = (gid % num_windows) * window_size;
   const ushort w = min((ushort)window_size, (ushort)(EXPONENT_BITS - bits));
 
-  POINT_projective res = POINT_ZERO;
+  POINT_jacobian res = POINT_ZERO;
   for(uint i = nstart; i < nend; i++) {
     uint ind = EXPONENT_get_bits(exps[i], bits, w);
 
@@ -60,7 +60,7 @@ KERNEL void POINT_multiexp(
   // e.g. 3a + 2b + 1c = a +
   //                    (a) + b +
   //                    ((a) + b) + c
-  POINT_projective acc = POINT_ZERO;
+  POINT_jacobian acc = POINT_ZERO;
   for(int j = bucket_len - 1; j >= 0; j--) {
     acc = POINT_add(acc, buckets[j]);
     res = POINT_add(res, acc);


### PR DESCRIPTION
In the GPU code for elliptic curve operatations we use the affine and the jacobian representation of a point. Rename the jacobian one from `_projective` to `_jacobian` to make clear that it is *not* the standard projective representation, but the jacobian representation.

I've made this change after a discussion with @DrPeterVanNostrand quite some time ago, but then forgot to PR it.