### PR TITLE
fix: enable dependency resolver v2 for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members = [
   "ec-gpu-gen",
   "gpu-tests",
 ]
+resolver = "2"


### PR DESCRIPTION
Using resolver version 2 (which is default in Rust editiion 2021), it is possible to run `cargo build --target wasm32-unknown-unknown` without any failures. Note that even before this change it was possible when `ec-gpu-gen` was used as a dependency, but with this change it becomes more apparent.

The problem was that the `rand` dev-dependency was enabling the `std` feature, which then led to `ff` pulling is `getrandom`, which has problems to be compiled to `wasm32-unknown-unknown` without setting the `js` feature.

Closes #32.