### PR TITLE
fix: update to Rust 2021 edition

### DIFF
--- a/ec-gpu-gen/Cargo.toml
+++ b/ec-gpu-gen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ec-gpu-gen"
 version = "0.4.0"
 authors = ["dignifiedquire <me@dignifiedquire.com>"]
-edition = "2018"
+edition = "2021"
 description = "Code generator for field and eliptic curve operations on the GPUs"
 homepage = "https://github.com/filecoin-project/ff-cl-gen"
 repository = "https://github.com/filecoin-project/ff-cl-gen"

--- a/ec-gpu/Cargo.toml
+++ b/ec-gpu/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ec-gpu"
 version = "0.2.0"
 authors = ["dignifiedquire <me@dignifiedquire.com>"]
-edition = "2018"
+edition = "2021"
 description = "Traits for field and eliptic curve operations on GPUs"
 homepage = "https://github.com/filecoin-project/ff-cl-gen"
 repository = "https://github.com/filecoin-project/ff-cl-gen"


### PR DESCRIPTION
As the resolver v2 is used on the workspace, it makes sense to upgrade all crates to Rust edition 2021.

BREAKING CHANGE: Switch to Rust edition 2021