### PR TITLE
chore: upgrade to bitvec 1.0.1 (#39)

### DIFF
--- a/ec-gpu-gen/Cargo.toml
+++ b/ec-gpu-gen/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/filecoin-project/ff-cl-gen"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-bitvec = "0.22.3"
+bitvec = "1.0.1"
 crossbeam-channel = "0.5.1"
 ec-gpu = "0.1.0"
 ff = { version = "0.12.0", default-features = false }

--- a/ec-gpu-gen/src/multiexp_cpu.rs
+++ b/ec-gpu-gen/src/multiexp_cpu.rs
@@ -129,10 +129,10 @@ pub struct DensityTracker {
 }
 
 impl<'a> QueryDensity for &'a DensityTracker {
-    type Iter = bitvec::slice::BitValIter<'a, Lsb0, usize>;
+    type Iter = bitvec::slice::BitValIter<'a, usize, Lsb0>;
 
     fn iter(self) -> Self::Iter {
-        self.bv.iter().by_val()
+        self.bv.iter().by_vals()
     }
 
     fn get_query_size(self) -> Option<usize> {


### PR DESCRIPTION
Performance for multiexp on the CPU was checked, there is no regression.

This update is needed as bitvec 0.22.3 is requiring funty 1.2 which was yanked.